### PR TITLE
beanstalkd tube-stats metrics collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Added
+- metrics-beanstalkd-tubes, get metrics from individual tubes
 
 ## [0.0.4] - 2016-02-18
 ### Fixed 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 ## Files
 
  * bin/metrics-beanstalkd.rb
+ * bin/metrics-beanstalkd-tube.rb
  * bin/check-beanstalk-jobs.rb
  * bin/check-beanstalk-watchers.rb
  * bin/check-beanstalk-watchers-to-buried.rb

--- a/bin/metrics-beanstalkd-tubes.rb
+++ b/bin/metrics-beanstalkd-tubes.rb
@@ -1,0 +1,102 @@
+#! /usr/bin/env ruby
+#
+# beanstalkd-metrics-tubes
+#
+# DESCRIPTION:
+#  This plugin checks the beanstalkd tube-stats, using the beaneater gem
+#
+# OUTPUT:
+#   metric-data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: beaneater
+#   gem: sensu-plugin
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Joakim Antman <antmanj@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'beaneater'
+
+#
+# Collects beanstalk tube metrics
+#
+class BeanstalkdMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :host,
+         description: 'beanstalkd server',
+         short:       '-h HOST',
+         long:        '--host HOST',
+         default:     'localhost'
+
+  option :port,
+         description: 'beanstalkd server port',
+         short:       '-p PORT',
+         long:        '--port PORT',
+         proc:        proc(&:to_i),
+         default:     11_300
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.beanstalkd"
+
+  option :tubes,
+         description: 'Comma separate list of tubes to collect metrics from',
+         short: '-t TUBES',
+         long: '--tubes TUBES',
+         default: '*'
+
+  option :stats,
+         description: 'Comma separate list of tube-stats to collect',
+         long: '--stats STATS',
+         default: '*'
+
+  def run
+    tubes.each do |tube|
+      output_stats(tube)
+    end
+    ok
+  end
+
+  private
+
+  INGORED_KEYS = ['name'].freeze
+
+  def output_stats(tube)
+    stats = tube.stats
+    stats.keys.sort.each do |key|
+      next unless matches_filter?(:stats, key)
+      next if INGORED_KEYS.include?(key)
+      output "#{config[:scheme]}.#{tube.name}.#{key}", stats[key]
+    end
+  end
+
+  def tubes
+    connection.tubes.all.select { |tube| matches_filter?(:tubes, tube.name) }
+  end
+
+  def matches_filter?(key, value)
+    @tube_filters ||= {}
+    unless @tube_filters.key?(key)
+      @tube_filters[key] = Array(config[key].split(',').map(&:strip))
+    end
+    @tube_filters[key].any? { |filter| File.fnmatch?(filter, value.to_s) }
+  end
+
+  def connection
+    @conn ||= Beaneater::Pool.new(["#{config[:host]}:#{config[:port]}"])
+  rescue => e
+    warning "could not connect to beanstalkd: #{e}"
+  end
+end


### PR DESCRIPTION
This plugin collects metrics per tube from a beanstalkd instance.