### PR TITLE
returns a warning if beanstalk tube is missing

### DIFF
--- a/bin/check-beanstalkd.rb
+++ b/bin/check-beanstalkd.rb
@@ -85,21 +85,27 @@ class BeanstalkdQueuesStatus < Sensu::Plugin::Check::CLI
   end
 
   def run
-    stats = acquire_beanstalkd_connection.tubes[config[:tube].to_s].stats
-    message 'All queues are healthy'
+    begin
+      stats = acquire_beanstalkd_connection.tubes[config[:tube].to_s].stats
+      message 'All queues are healthy'
 
-    warns, crits, msg = check_queues(stats)
-    msg.join("\n")
+      warns, crits, msg = check_queues(stats)
+      msg.join("\n")
 
-    if crits.size > 0 # rubocop:disable Style/ZeroLengthPredicate
-      message msg
-      critical
+      if crits.size > 0 # rubocop:disable Style/ZeroLengthPredicate
+        message msg
+        critical
+      end
+
+      if warns.size > 0 # rubocop:disable Style/ZeroLengthPredicate
+        message msg
+        warning
+      end
+
+    rescue
+      warning "could not find a tube named #{config[:tube]}"
     end
 
-    if warns.size > 0 # rubocop:disable Style/ZeroLengthPredicate
-      message msg
-      warning
-    end
     ok
   end
 


### PR DESCRIPTION
currently the check would return a failure NOT FOUND, this change allows for the correct
behaviour of beanstalkd, which is to GC tubes that are empty and have no clients connected.
In those situations, this check would raise an exception and not trigger a notification.

fixes #4 