### PR TITLE
Handle NOT_FOUND error as an empty queue, this fixes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Added
 - real tests with serverspec (@anakinj)
+- check-beanstalkd, ignore missing queues by default. Behaviour controlled by --alert-on-missing parameter. (@anakinj)
 
 ## [1.1.0] - 2017-08-15
 ### Added

--- a/test/integration/helpers/serverspec/check-beanstalk_shared_spec.rb
+++ b/test/integration/helpers/serverspec/check-beanstalk_shared_spec.rb
@@ -29,4 +29,12 @@ context 'when server contains tube with jobs' do
     its(:exit_status) { should eq 0 }
     its(:stdout) { should match(/beanstalkd queues check OK: All queues are healthy/) }
   end
+  describe command("#{check} -s 127.0.0.1 -p 11300 -t missing-tube -a warning") do
+    its(:exit_status) { should eq 1 }
+    its(:stdout) { should match(/Tube missing-tube is missing/) }
+  end
+  describe command("#{check} -s 127.0.0.1 -p 11300 -t missing-tube --alert-on-missing critical") do
+    its(:exit_status) { should eq 2 }
+    its(:stdout) { should match(/Tube missing-tube is missing/) }
+  end
 end


### PR DESCRIPTION
What do you think about generating empty stats for a queue that is not found? Should fix #4 