### PR TITLE
lock `test-kitchen` so dev dependencies do not fail on ruby < 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- fixed install issue with development dependencies with `test-kitchen` being unsatisfied with `1.17.0` as it requires ruby 2.3 or later (@majormoses)
+
 ## [2.0.0] - 2018-01-31
 ### Security
 - updated rubocop dependency to `~> 0.51.0` per: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418. (@majormoses)

--- a/sensu-plugins-beanstalk.gemspec
+++ b/sensu-plugins-beanstalk.gemspec
@@ -42,12 +42,15 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'github-markup',             '~> 1.3'
   s.add_development_dependency 'kitchen-docker',            '~> 2.6'
   s.add_development_dependency 'kitchen-localhost',         '~> 0.3'
+  # locked to keep ruby 2.1 support, this is pulled in by test-kitchen
+  s.add_development_dependency 'mixlib-shellout',           ['< 2.3.0', '~> 2.2']
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.4'
   s.add_development_dependency 'rubocop',                   '~> 0.51.0'
   s.add_development_dependency 'serverspec',                '~> 2.36.1'
-  s.add_development_dependency 'test-kitchen',              '~> 1.6'
+  # intentionally locked as 1.17 requires ruby 2.3+
+  s.add_development_dependency 'test-kitchen',              '~> 1.16.0'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Signed-off-by: Ben Abrams <me@benabrams.it>

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Fix install issue with ruby < `2.3`

#### Known Compatibility Issues
None