### PR TITLE
bump `sensu-plugin` dep to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Breaking Changes
+- bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
+
 ## [2.0.1] - 2012-02-01
 ### Fixed
 - fixed install issue with development dependencies with `test-kitchen` being unsatisfied with `1.17.0` as it requires ruby 2.3 or later (@majormoses)

--- a/sensu-plugins-beanstalk.gemspec
+++ b/sensu-plugins-beanstalk.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsBeanstalk::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin',     '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',     '~> 2.4'
 
   s.add_runtime_dependency 'beaneater',        '0.3.3'
   s.add_runtime_dependency 'beanstalk-client', '1.1.1'


### PR DESCRIPTION
This change is breaking, please refer to changelog for further details.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sensu-plugins/community/issues/26

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
pull in new features in `sensu-plugin` and remove built in event filtering and use native sensu filters instead.

#### Known Compatibility Issues
see changelog for details